### PR TITLE
Fix test SSH server close

### DIFF
--- a/devmand/gateway/src/devmand/test/cli/SshSessionTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/SshSessionTest.cpp
@@ -132,6 +132,10 @@ TEST_F(SshSessionTest, sessionStop) {
   session->setEvent(sessionEvent);
 }
 
+TEST_F(SshSessionTest, empty) {
+  // This tests the SSH server, to make sure it can cleanly start and close
+}
+
 } // namespace cli
 } // namespace test
 } // namespace devmand


### PR DESCRIPTION
It could trigger a segfault from libssh in case it called
disconnect before the server started reading on the session.

Close the session without calling ssh_disconnect, just close the
socket.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>