### PR TITLE
Start work on creating ssh layer without blocking

### DIFF
--- a/devmand/gateway/src/devmand/channels/cli/CliFlavour.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/CliFlavour.cpp
@@ -29,6 +29,7 @@ void EmptyInitializer::initialize(shared_ptr<SshSessionAsync> session) {
 }
 
 void UbiquitiInitializer::initialize(shared_ptr<SshSessionAsync> session) {
+  // TODO: return SemiFuture
   session->write("enable\n")
       .thenValue([=](...) { return session->write("ubnt\n"); })
       .thenValue([=](...) { return session->write("terminal length 0\n"); })
@@ -38,6 +39,7 @@ void UbiquitiInitializer::initialize(shared_ptr<SshSessionAsync> session) {
 string DefaultPromptResolver::resolvePrompt(
     shared_ptr<SshSessionAsync> session,
     const string& newline) {
+  // TODO: return SemiFuture
   session->read(DEFAULT_MILLIS).get(); // clear input, converges faster on
                                        // prompt
   for (int i = 1;; i++) {

--- a/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.cpp
@@ -62,7 +62,7 @@ IoConfigurationBuilder::~IoConfigurationBuilder() {
 
 shared_ptr<Cli> IoConfigurationBuilder::createAll(
     shared_ptr<CliCache> commandCache) {
-  return createAll(createSSH, commandCache);
+  return createAllUsingFactory(commandCache);
 }
 
 chrono::seconds IoConfigurationBuilder::loadTimeout(
@@ -76,31 +76,50 @@ chrono::seconds IoConfigurationBuilder::loadTimeout(
   }
 }
 
-shared_ptr<Cli> IoConfigurationBuilder::createAll(
-    function<shared_ptr<Cli>(
-        shared_ptr<IOThreadPoolExecutor>,
-        shared_ptr<ConnectionParameters>)> underlyingCliLayerFactory,
+shared_ptr<Cli> IoConfigurationBuilder::createAllUsingFactory(
     shared_ptr<CliCache> commandCache) {
   shared_ptr<folly::ThreadWheelTimekeeper> timekeeper =
       make_shared<folly::ThreadWheelTimekeeper>(); // TODO use singleton when
                                                    // folly is initialized
 
   // TODO make Executor sharing configurable
-  function<shared_ptr<Cli>()> cliFactory = [underlyingCliLayerFactory,
-                                            params = connectionParameters,
-                                            timekeeper,
-                                            commandCache]() -> shared_ptr<Cli> {
-    shared_ptr<IOThreadPoolExecutor> executor =
-        make_shared<IOThreadPoolExecutor>(
-            10, std::make_shared<NamedThreadFactory>("persession"));
-    return getIo(
-        params,
-        underlyingCliLayerFactory(executor, params),
-        timekeeper,
-        commandCache);
-  };
+  shared_ptr<IOThreadPoolExecutor> executor = make_shared<IOThreadPoolExecutor>(
+      10, std::make_shared<NamedThreadFactory>("persession"));
 
-  // create reconnecting cli
+  function<SemiFuture<shared_ptr<Cli>>()> cliFactory =
+      [executor, params = connectionParameters, timekeeper, commandCache]() {
+        return createPromptAwareCli(executor, params)
+            .via(executor.get())
+            .thenValue(
+                [executor, params, commandCache, timekeeper](
+                    shared_ptr<Cli> sshCli) -> shared_ptr<Cli> {
+                  MLOG(MDEBUG) << "[" << params->id
+                               << "] "
+                                  "Creating cli layers rcclli, ttcli, qcli";
+                  // create caching cli
+                  const shared_ptr<ReadCachingCli>& rccli =
+                      std::make_shared<ReadCachingCli>(
+                          params->id, sshCli, commandCache);
+                  // create timeout tracker
+                  shared_ptr<TimeoutTrackingCli> ttcli =
+                      TimeoutTrackingCli::make(
+                          params->id,
+                          rccli,
+                          timekeeper,
+                          std::make_shared<folly::CPUThreadPoolExecutor>(
+                              5, std::make_shared<NamedThreadFactory>("ttcli")),
+                          params->cmdTimeout);
+                  // create Queued cli
+                  shared_ptr<QueuedCli> qcli = QueuedCli::make(
+                      params->id,
+                      ttcli,
+                      std::make_shared<folly::CPUThreadPoolExecutor>(
+                          2, std::make_shared<NamedThreadFactory>("qcli")));
+                  return qcli;
+                });
+      };
+
+  // create reconnecting cli that uses cliFactory to establish ssh connection
   shared_ptr<CPUThreadPoolExecutor> rExecutor =
       std::make_shared<CPUThreadPoolExecutor>(
           2, std::make_shared<NamedThreadFactory>("rcli"));
@@ -120,64 +139,59 @@ shared_ptr<Cli> IoConfigurationBuilder::createAll(
   return kaCli;
 }
 
-shared_ptr<Cli> IoConfigurationBuilder::createSSH(
+Future<shared_ptr<Cli>> IoConfigurationBuilder::createPromptAwareCli(
     shared_ptr<IOThreadPoolExecutor> executor,
     shared_ptr<ConnectionParameters> params) {
-  MLOG(MDEBUG) << "Creating CLI ssh device for " << params->id
-               << " (host: " << params->ip << ")";
+  MLOG(MDEBUG) << "Creating CLI ssh device for " << params->id << " ("
+               << params->ip << ":" << params->port << ")";
 
   // create session
-  const std::shared_ptr<SshSessionAsync>& session =
+  std::shared_ptr<SshSessionAsync> session =
       std::make_shared<SshSessionAsync>(params->id, executor);
-  // opening SSH connection
+  // open SSH connection
+
+  MLOG(MDEBUG) << "[" << params->id
+               << "] "
+                  "Opening shell";
+  // TODO: do this using future chaining
   session
-      ->openShell(
-          params->ip,
-          params->port,
-          params->username,
-          params->password)
-      .get(); // TODO make this async
+      ->openShell(params->ip, params->port, params->username, params->password)
+      .get();
 
+  MLOG(MDEBUG) << "[" << params->id
+               << "] "
+                  "Setting flavour";
   shared_ptr<CliFlavour> cl = params->flavour;
-
   // create CLI
-  const shared_ptr<PromptAwareCli>& cli =
+  shared_ptr<PromptAwareCli> cli =
       std::make_shared<PromptAwareCli>(session, cl);
-
+  MLOG(MDEBUG) << "[" << params->id
+               << "] "
+                  "Initializing cli";
   // initialize CLI
+  // TODO: do this using future chaining:
+  //  via(executor.get())
+  //      .thenValue([params, cli, session](...) -> SemiFuture<shared_ptr<Cli>>
+  //      {
+
   cli->initializeCli();
   // resolve prompt needs to happen
+  MLOG(MDEBUG) << "[" << params->id
+               << "] "
+                  "Resolving prompt";
+  // TODO: do this using future chaining
   cli->resolvePrompt();
-  // create async data reader
+
+  MLOG(MDEBUG) << "[" << params->id
+               << "] "
+                  "Creating async data reader";
   event* sessionEvent = SshSocketReader::getInstance().addSshReader(
       readCallback, session->getSshFd(), session.get());
   session->setEvent(sessionEvent);
-  return cli;
-}
-
-shared_ptr<Cli> IoConfigurationBuilder::getIo(
-    shared_ptr<ConnectionParameters> params,
-    shared_ptr<Cli> underlyingCliLayer,
-    shared_ptr<folly::ThreadWheelTimekeeper> timekeeper,
-    shared_ptr<CliCache> commandCache) {
-  // create caching cli
-  const shared_ptr<ReadCachingCli>& ccli = std::make_shared<ReadCachingCli>(
-      params->id, underlyingCliLayer, commandCache);
-  // create timeout tracker
-  shared_ptr<TimeoutTrackingCli> ttcli = TimeoutTrackingCli::make(
-      params->id,
-      ccli,
-      timekeeper,
-      std::make_shared<folly::CPUThreadPoolExecutor>(
-          5, std::make_shared<NamedThreadFactory>("ttcli")),
-      params->cmdTimeout);
-  // create Queued cli
-  shared_ptr<QueuedCli> qcli = QueuedCli::make(
-      params->id,
-      ttcli,
-      std::make_shared<folly::CPUThreadPoolExecutor>(
-          2, std::make_shared<NamedThreadFactory>("qcli")));
-  return qcli;
+  MLOG(MDEBUG) << "[" << params->id
+               << "] "
+                  "SSH layer configured";
+  return makeFuture(cli);
 }
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
+++ b/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
@@ -22,6 +22,7 @@ using devmand::channels::cli::CliFlavour;
 using namespace std;
 
 using folly::IOThreadPoolExecutor;
+using folly::SemiFuture;
 
 static constexpr auto configKeepAliveIntervalSeconds =
     "keepAliveIntervalSeconds";
@@ -50,21 +51,11 @@ class IoConfigurationBuilder {
 
   shared_ptr<ConnectionParameters> connectionParameters;
 
-  shared_ptr<Cli> createAll(
-      function<shared_ptr<Cli>(
-          shared_ptr<folly::IOThreadPoolExecutor>,
-          shared_ptr<ConnectionParameters>)> underlyingCliLayerFactory,
-      shared_ptr<CliCache> commandCache);
+  shared_ptr<Cli> createAllUsingFactory(shared_ptr<CliCache> commandCache);
 
-  static shared_ptr<Cli> createSSH(
+  static Future<shared_ptr<Cli>> createPromptAwareCli(
       shared_ptr<folly::IOThreadPoolExecutor> executor,
       shared_ptr<ConnectionParameters> params);
-
-  static shared_ptr<Cli> getIo(
-      shared_ptr<ConnectionParameters> params,
-      shared_ptr<Cli> underlyingCliLayer,
-      shared_ptr<folly::ThreadWheelTimekeeper> timekeeper,
-      shared_ptr<CliCache> commandCache = ReadCachingCli::createCache());
 
   static chrono::seconds loadTimeout(
       const std::map<std::string, std::string>& plaintextCliKv,

--- a/devmand/gateway/src/devmand/channels/cli/ReconnectingCli.h
+++ b/devmand/gateway/src/devmand/channels/cli/ReconnectingCli.h
@@ -31,7 +31,7 @@ class ReconnectingCli : public Cli,
   static shared_ptr<ReconnectingCli> make(
       string id,
       shared_ptr<Executor> executor,
-      function<shared_ptr<Cli>()>&& createCliStack,
+      function<SemiFuture<shared_ptr<Cli>>()>&& createCliStack,
       shared_ptr<Timekeeper> timekeeper,
       chrono::milliseconds quietPeriod = chrono::seconds(5));
 
@@ -45,13 +45,13 @@ class ReconnectingCli : public Cli,
   struct ReconnectParameters {
     string id;
 
-    atomic<bool> isReconnecting;
+    atomic<bool> isReconnecting; // TODO: merge with maybeCli
 
     atomic<bool> shutdown;
 
     shared_ptr<Executor> executor;
 
-    function<shared_ptr<Cli>()> createCliStack;
+    function<SemiFuture<shared_ptr<Cli>>()> createCliStack;
 
     mutex cliMutex;
 
@@ -68,7 +68,7 @@ class ReconnectingCli : public Cli,
   ReconnectingCli(
       string id,
       shared_ptr<Executor> executor,
-      function<shared_ptr<Cli>()>&& createCliStack,
+      function<SemiFuture<shared_ptr<Cli>>()>&& createCliStack,
       shared_ptr<Timekeeper> timekeeper,
       chrono::milliseconds quietPeriod);
 

--- a/devmand/gateway/src/devmand/test/cli/ReconnectingSshTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/ReconnectingSshTest.cpp
@@ -64,8 +64,7 @@ static DeviceConfig getConfig(
   kvPairs.insert(std::make_pair("username", "root"));
   kvPairs.insert(std::make_pair("password", "root"));
   kvPairs.insert(std::make_pair(
-      configMaxCommandTimeoutSeconds,
-      to_string(commandTimeout.count()))); // count?
+      configMaxCommandTimeoutSeconds, to_string(commandTimeout.count())));
   chnlCfg.kvPairs = kvPairs;
   deviceConfig.channelConfigs.insert(std::make_pair("cli", chnlCfg));
   deviceConfig.ip = "localhost";


### PR DESCRIPTION
Make IoConfigurationBuilder::createPromptAwareCli return Future<sp<Cli>>
as this allows replacing .get() methods with future chaining.