### PR TITLE
Fix keepalive after accidental removal

### DIFF
--- a/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.cpp
@@ -136,6 +136,7 @@ shared_ptr<Cli> IoConfigurationBuilder::createAllUsingFactory(
       kaExecutor,
       timekeeper,
       connectionParameters->kaTimeout);
+  kaCli->start();
   return kaCli;
 }
 

--- a/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
@@ -132,4 +132,8 @@ Future<string> KeepaliveCli::executeWrite(const WriteCommand& cmd) {
   return cli->executeWrite(cmd);
 }
 
+void KeepaliveCli::start() {
+  sendKeepAliveCommand();
+}
+
 } // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.h
+++ b/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.h
@@ -36,6 +36,11 @@ class KeepaliveCli : public Cli, public enable_shared_from_this<KeepaliveCli> {
 
   ~KeepaliveCli() override;
 
+  /*
+   * Must be called after constructor to kick start keepalive.
+   */
+  void start();
+
   folly::Future<string> executeRead(const ReadCommand& cmd) override;
 
   folly::Future<string> executeWrite(const WriteCommand& cmd) override;


### PR DESCRIPTION
kaCli.init() must be called after KeepaliveCli constructor is called.