### PR TITLE
Fix ReconnectingCli deadlock on destructor

### DIFF
--- a/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.cpp
@@ -152,7 +152,7 @@ shared_ptr<Cli> IoConfigurationBuilder::createAllUsingFactory(
 }
 
 Future<shared_ptr<Cli>> IoConfigurationBuilder::createPromptAwareCli(
-    shared_ptr<IOThreadPoolExecutor> executor,
+    shared_ptr<folly::Executor> executor,
     shared_ptr<ConnectionParameters> params) {
   MLOG(MDEBUG) << "Creating CLI ssh device for " << params->id << " ("
                << params->ip << ":" << params->port << ")";

--- a/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
+++ b/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
@@ -50,7 +50,7 @@ class IoConfigurationBuilder {
   shared_ptr<Cli> createAll(shared_ptr<CliCache> commandCache);
 
   static Future<shared_ptr<Cli>> createPromptAwareCli(
-      shared_ptr<folly::IOThreadPoolExecutor> executor,
+      shared_ptr<folly::Executor> executor,
       shared_ptr<ConnectionParameters> params);
 
   static shared_ptr<ConnectionParameters> makeConnectionParameters(

--- a/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
@@ -85,7 +85,7 @@ void KeepaliveCli::triggerSendKeepAliveCommand(
     return;
   }
   ReadCommand cmd =
-      ReadCommand::create(keepaliveParameters->keepAliveCommand, false);
+      ReadCommand::create(keepaliveParameters->keepAliveCommand, true);
   MLOG(MDEBUG) << "[" << keepaliveParameters->id << "] (" << cmd.getIdx()
                << ") "
                << "triggerSendKeepAliveCommand created new command";

--- a/devmand/gateway/src/devmand/channels/cli/ReadCachingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/ReadCachingCli.cpp
@@ -45,7 +45,8 @@ devmand::channels::cli::ReadCachingCli::executeRead(const ReadCommand cmd) {
       .thenValue([=](string output) {
         cache->wlock()->insert(cmd.raw(), output);
         return output;
-      });
+      })
+      .semi();
 }
 
 devmand::channels::cli::ReadCachingCli::ReadCachingCli(

--- a/devmand/gateway/src/devmand/channels/cli/ReconnectingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/ReconnectingCli.cpp
@@ -177,7 +177,8 @@ SemiFuture<string> ReconnectingCli::executeSomething(
               // TODO: exception type is not preserved,
               // queueEntry.promise->setException(e) results in std::exception
               throw cpException;
-            });
+            })
+        .semi();
   } else {
     return makeFuture<string>(runtime_error("Not connected"));
   }

--- a/devmand/gateway/src/devmand/channels/cli/SshSessionAsync.h
+++ b/devmand/gateway/src/devmand/channels/cli/SshSessionAsync.h
@@ -55,6 +55,7 @@ class SshSessionAsync : public std::enable_shared_from_this<SshSessionAsync>,
   event* sessionEvent = nullptr;
   spsc_queue<string, capacity<200>> readQueue;
   std::atomic_bool reading;
+  std::atomic_bool callbackFinished;
   std::atomic_bool matchingExpectedOutput;
   struct ReadingState {
     shared_ptr<Promise<string>> promise;
@@ -82,6 +83,7 @@ class SshSessionAsync : public std::enable_shared_from_this<SshSessionAsync>,
   socket_t getSshFd();
   void matchExpectedOutput();
   static void failCurrentRead(runtime_error e, shared_ptr<Promise<string>> ptr);
+  void unregisterEvent();
 };
 
 } // namespace sshsession

--- a/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
@@ -63,17 +63,21 @@ folly::SemiFuture<std::string> TimeoutTrackingCli::executeRead(
   return executeSomething(
              cmd,
              "TTCli.executeRead",
-             [this, cmd]() {
-               return timeoutTrackingParameters->cli->executeRead(cmd);
+             [params = timeoutTrackingParameters, cmd]() {
+               return params->cli->executeRead(cmd);
              })
       .semi();
 }
 
 folly::SemiFuture<std::string> TimeoutTrackingCli::executeWrite(
     const WriteCommand cmd) {
-  return executeSomething(cmd, "TTCli.executeWrite", [this, cmd]() {
-    return timeoutTrackingParameters->cli->executeWrite(cmd);
-  });
+  return executeSomething(
+             cmd,
+             "TTCli.executeWrite",
+             [params = timeoutTrackingParameters, cmd]() {
+               return params->cli->executeWrite(cmd);
+             })
+      .semi();
 }
 
 Future<string> TimeoutTrackingCli::executeSomething(

--- a/devmand/gateway/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
@@ -108,35 +108,6 @@ TEST_F(TimeoutCliTest, cleanDestructOnSuccess) {
   ASSERT_EQ(move(future).via(testExec.get()).get(10s), "returning");
 }
 
-TEST_F(TimeoutCliTest, DISABLED_cleanDestruct) {
-  shared_ptr<CPUThreadPoolExecutor> mockCliExecutor =
-      make_shared<CPUThreadPoolExecutor>(2);
-  vector<unsigned int> durations = {5};
-  auto delegate =
-      make_shared<AsyncCli>(make_shared<EchoCli>(), mockCliExecutor, durations);
-  shared_ptr<CPUThreadPoolExecutor> executor =
-      make_shared<CPUThreadPoolExecutor>(1);
-  shared_ptr<folly::ThreadWheelTimekeeper> timekeeper =
-      make_shared<folly::ThreadWheelTimekeeper>();
-  shared_ptr<TimeoutTrackingCli> cli =
-      TimeoutTrackingCli::make("test", delegate, timekeeper, executor, 1000ms);
-  Future<string> future =
-      cli->executeRead(ReadCommand::create("not returning"))
-          .via(mockCliExecutor.get())
-          .thenError(tag_t<FutureTimeout>{}, [](FutureTimeout const& e) {
-            MLOG(MDEBUG) << "Read completed with error: " << e.what();
-            return Future<string>(e);
-          });
-  executor.reset();
-  timekeeper.reset();
-  cli.reset();
-  // Wait for async session to finish
-  mockCliExecutor->join();
-  // Assert future finished
-  ASSERT_EQ(true, future.isReady());
-  ASSERT_EQ(true, future.hasException());
-}
-
 } // namespace cli
 } // namespace test
 } // namespace devmand

--- a/devmand/gateway/src/devmand/test/cli/utils/Log.cpp
+++ b/devmand/gateway/src/devmand/test/cli/utils/Log.cpp
@@ -18,11 +18,12 @@ using namespace devmand::channels::cli;
 
 atomic_bool loggingInitialized(false);
 
-void initLog() {
+void initLog(uint32_t verbosity) {
   if (loggingInitialized.load()) {
+    magma::set_verbosity(verbosity);
     return;
   }
-  Engine::initLogging(MDEBUG, true);
+  Engine::initLogging(verbosity, true);
   loggingInitialized.store(true);
   MLOG(MDEBUG) << "Logging for test initialized";
 }

--- a/devmand/gateway/src/devmand/test/cli/utils/Log.h
+++ b/devmand/gateway/src/devmand/test/cli/utils/Log.h
@@ -21,7 +21,7 @@ using namespace std;
 
 extern atomic_bool loggingInitialized;
 
-extern void initLog();
+extern void initLog(uint32_t verbosity = MDEBUG);
 
 } // namespace log
 } // namespace utils

--- a/devmand/gateway/src/devmand/test/cli/utils/Ssh.cpp
+++ b/devmand/gateway/src/devmand/test/cli/utils/Ssh.cpp
@@ -237,6 +237,12 @@ shared_ptr<server> startSshServer(
               handleCommand(chan, allInput);
               ssh_channel_write(
                   chan, prompt.c_str(), uint32_t(prompt.length()));
+
+              {
+                lock_guard<std::mutex> lg(retVal->received_guard);
+                retVal->received = allInput.str();
+              }
+
             } else {
               wasEnter = false;
               ssh_channel_write(chan, buf, uint32_t(i));

--- a/devmand/gateway/src/devmand/test/cli/utils/Ssh.h
+++ b/devmand/gateway/src/devmand/test/cli/utils/Ssh.h
@@ -32,13 +32,21 @@ extern void initSsh();
 extern shared_ptr<CPUThreadPoolExecutor> testExecutor;
 
 struct server {
+ public:
   string id;
   ssh_bind sshbind = nullptr;
   ssh_session session = nullptr;
   Future<Unit> serverFuture;
+  mutex received_guard;
+  string received = "";
 
   bool isConnected() {
     return session != nullptr and ssh_is_connected(session);
+  }
+
+  string getReceived() {
+    lock_guard<std::mutex> lg(received_guard);
+    return received;
   }
 
   void close() {


### PR DESCRIPTION
For some reason, shared_from_this in thenError callback prevented
the destructor to release the executor...

Using raw pointer instead, with params as protection.

+ Use proper ex type when asserting exception in tests

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>