### PR TITLE
Externalize cli Executors to Engine

### DIFF
--- a/devmand/gateway/src/devmand/Application.cpp
+++ b/devmand/gateway/src/devmand/Application.cpp
@@ -77,6 +77,11 @@ channels::ping::Engine& Application::getPingEngine(folly::IPAddress ip) {
   }
 }
 
+channels::cli::Engine& Application::getCliEngine() {
+  assert(cliEngine != nullptr);
+  return *cliEngine;
+}
+
 std::string Application::getName() const {
   return name;
 }

--- a/devmand/gateway/src/devmand/Application.h
+++ b/devmand/gateway/src/devmand/Application.h
@@ -95,6 +95,7 @@ class Application : public MetricSink {
   channels::snmp::Engine& getSnmpEngine();
   channels::ping::Engine& getPingEngine(IPVersion ipv = IPVersion::v4);
   channels::ping::Engine& getPingEngine(folly::IPAddress ip);
+  channels::cli::Engine& getCliEngine();
 
  private:
   void pollDevices();

--- a/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
@@ -19,7 +19,7 @@ shared_ptr<KeepaliveCli> KeepaliveCli::make(
     string id,
     shared_ptr<Cli> cli,
     shared_ptr<folly::Executor> parentExecutor,
-    shared_ptr<folly::ThreadWheelTimekeeper> timekeeper,
+    shared_ptr<folly::Timekeeper> timekeeper,
     chrono::milliseconds heartbeatInterval,
     string keepAliveCommand,
     chrono::milliseconds backoffAfterKeepaliveTimeout) {
@@ -39,7 +39,7 @@ KeepaliveCli::KeepaliveCli(
     string _id,
     shared_ptr<Cli> _cli,
     shared_ptr<Executor> _parentExecutor,
-    shared_ptr<ThreadWheelTimekeeper> _timekeeper,
+    shared_ptr<Timekeeper> _timekeeper,
     chrono::milliseconds _heartbeatInterval,
     string _keepAliveCommand,
     chrono::milliseconds _backoffAfterKeepaliveTimeout) {

--- a/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.h
+++ b/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.h
@@ -28,7 +28,7 @@ class KeepaliveCli : public Cli {
       string id,
       shared_ptr<Cli> _cli,
       shared_ptr<folly::Executor> parentExecutor,
-      shared_ptr<folly::ThreadWheelTimekeeper> _timekeeper,
+      shared_ptr<folly::Timekeeper> _timekeeper,
       chrono::milliseconds heartbeatInterval = defaultKeepaliveInterval,
       string keepAliveCommand = "",
       chrono::milliseconds backoffAfterKeepaliveTimeout = chrono::seconds(5));
@@ -43,7 +43,7 @@ class KeepaliveCli : public Cli {
   struct KeepaliveParameters {
     string id;
     shared_ptr<Cli> cli; // underlying cli layer
-    shared_ptr<folly::ThreadWheelTimekeeper> timekeeper;
+    shared_ptr<folly::Timekeeper> timekeeper;
     shared_ptr<folly::Executor> parentExecutor;
     folly::Executor::KeepAlive<folly::SerialExecutor> serialExecutorKeepAlive;
     string keepAliveCommand;
@@ -60,7 +60,7 @@ class KeepaliveCli : public Cli {
       string id,
       shared_ptr<Cli> _cli,
       shared_ptr<folly::Executor> parentExecutor,
-      shared_ptr<folly::ThreadWheelTimekeeper> _timekeeper,
+      shared_ptr<folly::Timekeeper> _timekeeper,
       chrono::milliseconds heartbeatInterval,
       string keepAliveCommand,
       chrono::milliseconds backoffAfterKeepaliveTimeout);

--- a/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
@@ -18,7 +18,7 @@ using devmand::channels::cli::Command;
 shared_ptr<TimeoutTrackingCli> TimeoutTrackingCli::make(
     string id,
     shared_ptr<Cli> cli,
-    shared_ptr<folly::ThreadWheelTimekeeper> timekeeper,
+    shared_ptr<folly::Timekeeper> timekeeper,
     shared_ptr<folly::Executor> executor,
     std::chrono::milliseconds timeoutInterval) {
   return shared_ptr<TimeoutTrackingCli>(
@@ -28,7 +28,7 @@ shared_ptr<TimeoutTrackingCli> TimeoutTrackingCli::make(
 TimeoutTrackingCli::TimeoutTrackingCli(
     string _id,
     shared_ptr<Cli> _cli,
-    shared_ptr<folly::ThreadWheelTimekeeper> _timekeeper,
+    shared_ptr<folly::Timekeeper> _timekeeper,
     shared_ptr<folly::Executor> _executor,
     std::chrono::milliseconds _timeoutInterval) {
   timeoutTrackingParameters =

--- a/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.h
+++ b/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.h
@@ -31,7 +31,7 @@ class TimeoutTrackingCli : public Cli {
   static shared_ptr<TimeoutTrackingCli> make(
       string id,
       shared_ptr<Cli> cli,
-      shared_ptr<folly::ThreadWheelTimekeeper> timekeeper,
+      shared_ptr<folly::Timekeeper> timekeeper,
       shared_ptr<folly::Executor> executor,
       std::chrono::milliseconds _timeoutInterval = defaultCommandTimeout);
 
@@ -45,7 +45,7 @@ class TimeoutTrackingCli : public Cli {
   struct TimeoutTrackingParameters {
     string id;
     shared_ptr<Cli> cli; // underlying cli layer
-    shared_ptr<folly::ThreadWheelTimekeeper> timekeeper;
+    shared_ptr<folly::Timekeeper> timekeeper;
     shared_ptr<folly::Executor> executor;
     const std::chrono::milliseconds timeoutInterval;
     atomic<bool> shutdown;
@@ -55,7 +55,7 @@ class TimeoutTrackingCli : public Cli {
   TimeoutTrackingCli(
       string id,
       shared_ptr<Cli> _cli,
-      shared_ptr<folly::ThreadWheelTimekeeper> _timekeeper,
+      shared_ptr<folly::Timekeeper> _timekeeper,
       shared_ptr<folly::Executor> _executor,
       std::chrono::milliseconds _timeoutInterval);
 

--- a/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
@@ -8,6 +8,9 @@
 #include <devmand/channels/cli/Spd2Glog.h>
 #include <devmand/channels/cli/engine/Engine.h>
 #include <event2/thread.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
 #include <libssh/callbacks.h>
 #include <libssh/libssh.h>
 #include <spdlog/spdlog.h>
@@ -26,23 +29,46 @@ void Engine::closeLogging() {
 }
 
 void Engine::initSsh() {
-  ssh_threads_set_callbacks(ssh_threads_get_pthread());
-  ssh_init();
-  ssh_set_log_level(SSH_LOG_NOLOG);
-  evthread_use_pthreads();
+  bool f = false;
+  if (sshInitialized.compare_exchange_strong(f, true)) {
+    ssh_threads_set_callbacks(ssh_threads_get_pthread());
+    ssh_init();
+    ssh_set_log_level(SSH_LOG_NOLOG);
+    evthread_use_pthreads();
+  } else {
+    MLOG(MWARNING) << "SSH already initialized";
+  }
 }
 
 void Engine::initLogging(uint32_t verbosity, bool callInitMlog) {
-  if (callInitMlog) {
-    magma::init_logging("devmand");
+  bool f = false;
+  if (loggingInitialized.compare_exchange_strong(f, true)) {
+    if (callInitMlog) {
+      magma::init_logging("devmand");
+    }
+    magma::set_verbosity(verbosity);
+    // IInitialize spd -> glog sink for YDK lib
+    spdlog::create<Spd2Glog>("ydk");
+    spdlog::set_level(spdlog::level::level_enum::info);
+  } else {
+    MLOG(MWARNING) << "Logging already initialized";
   }
-  magma::set_verbosity(verbosity);
-  // IInitialize spd -> glog sink for YDK lib
-  spdlog::create<Spd2Glog>("ydk");
-  spdlog::set_level(spdlog::level::level_enum::info);
 }
 
-Engine::Engine() : channels::Engine("Cli") {
+Engine::Engine()
+    : channels::Engine("Cli"),
+      timekeeper(make_shared<folly::ThreadWheelTimekeeper>()),
+      sshCliExecutor(std::make_shared<folly::IOThreadPoolExecutor>(
+          5,
+          std::make_shared<folly::NamedThreadFactory>("sshCli"))),
+      commonExecutor(std::make_shared<folly::IOThreadPoolExecutor>(
+          5,
+          std::make_shared<folly::NamedThreadFactory>("commonCli"))),
+      kaCliExecutor(std::make_shared<folly::CPUThreadPoolExecutor>(
+          5,
+          std::make_shared<folly::NamedThreadFactory>("kaCli"))) {
+  // TODO use singleton when folly is initialized
+  // TODO switch to IOThreadPool for common pool once blocking issues are solved
   Engine::initSsh();
   Engine::initLogging();
   MLOG(MERROR) << "Cli engine started";
@@ -52,6 +78,20 @@ Engine::~Engine() {
   Engine::closeSsh();
   Engine::closeLogging();
   MLOG(MDEBUG) << "Cli engine closed";
+}
+
+shared_ptr<folly::ThreadWheelTimekeeper> Engine::getTimekeeper() {
+  return timekeeper;
+}
+
+shared_ptr<folly::Executor> Engine::getExecutor(
+    Engine::executorRequestType requestType) const {
+  if (requestType == kaCli) {
+    return kaCliExecutor;
+  } else if (requestType == sshCli) {
+    return sshCliExecutor;
+  }
+  return commonExecutor;
 }
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/channels/cli/engine/Engine.h
+++ b/devmand/gateway/src/devmand/channels/cli/engine/Engine.h
@@ -10,11 +10,19 @@
 #define LOG_WITH_GLOG
 
 #include <devmand/channels/Engine.h>
+#include <folly/Executor.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
 #include <magma_logging.h>
+#include <atomic>
 
 namespace devmand {
 namespace channels {
 namespace cli {
+
+using namespace std;
+
+static atomic<bool> loggingInitialized(false);
+static atomic<bool> sshInitialized(false);
 
 class Engine : public channels::Engine {
  public:
@@ -31,6 +39,27 @@ class Engine : public channels::Engine {
   static void closeLogging();
   static void initSsh();
   static void closeSsh();
+
+  shared_ptr<folly::ThreadWheelTimekeeper> timekeeper;
+  shared_ptr<folly::Executor> sshCliExecutor;
+  shared_ptr<folly::Executor> commonExecutor;
+  shared_ptr<folly::Executor> kaCliExecutor;
+
+  shared_ptr<folly::ThreadWheelTimekeeper> getTimekeeper();
+
+  enum executorRequestType {
+    sshCli,
+    paCli,
+    rcCli,
+    ttCli,
+    qCli,
+    rCli,
+    kaCli,
+    plaintextCliDevice
+  };
+
+  shared_ptr<folly::Executor> getExecutor(
+      executorRequestType requestType) const;
 };
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/devices/cli/PlaintextCliDevice.h
+++ b/devmand/gateway/src/devmand/devices/cli/PlaintextCliDevice.h
@@ -10,6 +10,7 @@
 #define LOG_WITH_GLOG
 #include <magma_logging.h>
 
+#include <devmand/Application.h>
 #include <devmand/channels/cli/Channel.h>
 #include <devmand/channels/cli/Command.h>
 #include <devmand/channels/cli/ReadCachingCli.h>

--- a/devmand/gateway/src/devmand/devices/cli/StructuredUbntDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/cli/StructuredUbntDevice.cpp
@@ -291,7 +291,8 @@ static shared_ptr<Nis> parseNetworks(Channel& channel) {
 unique_ptr<devices::Device> StructuredUbntDevice::createDevice(
     Application& app,
     const cartography::DeviceConfig& deviceConfig) {
-  IoConfigurationBuilder ioConfigurationBuilder(deviceConfig);
+  IoConfigurationBuilder ioConfigurationBuilder(
+      deviceConfig, app.getCliEngine());
   auto cmdCache = ReadCachingCli::createCache();
   const std::shared_ptr<Channel>& channel = std::make_shared<Channel>(
       deviceConfig.id, ioConfigurationBuilder.createAll(cmdCache));

--- a/devmand/gateway/src/devmand/devices/cli/StructuredUbntDevice.h
+++ b/devmand/gateway/src/devmand/devices/cli/StructuredUbntDevice.h
@@ -10,6 +10,7 @@
 #define LOG_WITH_GLOG
 #include <magma_logging.h>
 
+#include <devmand/Application.h>
 #include <devmand/channels/cli/Channel.h>
 #include <devmand/channels/cli/Command.h>
 #include <devmand/channels/cli/ReadCachingCli.h>

--- a/devmand/gateway/src/devmand/test/cli/QueuedCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/QueuedCliTest.cpp
@@ -172,7 +172,8 @@ TEST_F(QueuedCliTest, cleanDestructOnSuccess) {
   }
 
   for (uint i = 1; i < 10; i++) {
-    EXPECT_THROW(move(futures.at(i)).via(testExec.get()).get(10s), runtime_error);
+    EXPECT_THROW(
+        move(futures.at(i)).via(testExec.get()).get(10s), runtime_error);
   }
 
   MLOG(MDEBUG) << "Waiting for test executor to finish";

--- a/devmand/gateway/src/devmand/test/cli/ReconnectingSshTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/ReconnectingSshTest.cpp
@@ -33,19 +33,21 @@ using namespace folly;
 using devmand::channels::cli::sshsession::readCallback;
 using devmand::channels::cli::sshsession::SshSession;
 using devmand::channels::cli::sshsession::SshSessionAsync;
-using folly::IOThreadPoolExecutor;
 using namespace devmand::cartography;
 using namespace devmand::devices;
 using namespace devmand::devices::cli;
 
 using namespace chrono_literals;
 
+// test log initializer must be first to set up logging for tests correctly
+static devmand::test::utils::log::TestLogInitializer log;
+static channels::cli::Engine cliEngine;
+
 class ReconnectingSshTest : public ::testing::Test {
  protected:
   shared_ptr<server> ssh;
+
   void SetUp() override {
-    devmand::test::utils::log::initLog();
-    devmand::test::utils::ssh::initSsh();
     ssh = startSshServer();
   }
 
@@ -97,7 +99,9 @@ static void ensureConnected(const shared_ptr<Cli>& cli) {
 TEST_F(ReconnectingSshTest, commandTimeout) {
   int cmdTimeout = 5;
   IoConfigurationBuilder ioConfigurationBuilder(
-      getConfig("9999", chrono::seconds(cmdTimeout), chrono::seconds(10)));
+      getConfig(
+          "9999", std::chrono::seconds(cmdTimeout), std::chrono::seconds(10)),
+      cliEngine);
   shared_ptr<Cli> cli =
       ioConfigurationBuilder.createAll(ReadCachingCli::createCache());
   ensureConnected(cli);
@@ -124,7 +128,9 @@ TEST_F(ReconnectingSshTest, commandTimeout) {
 TEST_F(ReconnectingSshTest, serverDisconnectSendCommands) {
   int cmdTimeout = 60;
   IoConfigurationBuilder ioConfigurationBuilder(
-      getConfig("9999", chrono::seconds(cmdTimeout), chrono::seconds(60)));
+      getConfig(
+          "9999", std::chrono::seconds(cmdTimeout), std::chrono::seconds(60)),
+      cliEngine);
   shared_ptr<Cli> cli =
       ioConfigurationBuilder.createAll(ReadCachingCli::createCache());
 
@@ -137,8 +143,12 @@ TEST_F(ReconnectingSshTest, serverDisconnectSendCommands) {
 TEST_F(ReconnectingSshTest, serverDisconnectWaithForKeepalive) {
   int cmdTimeout = 5;
   int keepaliveFreq = 5;
-  IoConfigurationBuilder ioConfigurationBuilder(getConfig(
-      "9999", chrono::seconds(cmdTimeout), chrono::seconds(keepaliveFreq)));
+  IoConfigurationBuilder ioConfigurationBuilder(
+      getConfig(
+          "9999",
+          std::chrono::seconds(cmdTimeout),
+          std::chrono::seconds(keepaliveFreq)),
+      cliEngine);
   shared_ptr<Cli> cli =
       ioConfigurationBuilder.createAll(ReadCachingCli::createCache());
 
@@ -166,8 +176,12 @@ TEST_F(ReconnectingSshTest, serverDisconnectWaithForKeepalive) {
 TEST_F(ReconnectingSshTest, keepalive) {
   int cmdTimeout = 5;
   int keepaliveTimeout = 5;
-  IoConfigurationBuilder ioConfigurationBuilder(getConfig(
-      "9999", chrono::seconds(cmdTimeout), chrono::seconds(keepaliveTimeout)));
+  IoConfigurationBuilder ioConfigurationBuilder(
+      getConfig(
+          "9999",
+          std::chrono::seconds(cmdTimeout),
+          std::chrono::seconds(keepaliveTimeout)),
+      cliEngine);
   shared_ptr<Cli> cli =
       ioConfigurationBuilder.createAll(ReadCachingCli::createCache());
 

--- a/devmand/gateway/src/devmand/test/cli/utils/Log.cpp
+++ b/devmand/gateway/src/devmand/test/cli/utils/Log.cpp
@@ -28,6 +28,11 @@ void initLog(uint32_t verbosity) {
   MLOG(MDEBUG) << "Logging for test initialized";
 }
 
+TestLogInitializer::TestLogInitializer() {
+  initLog();
+  MLOG(MDEBUG) << "Initialized test logging";
+}
+
 } // namespace log
 } // namespace utils
 } // namespace test

--- a/devmand/gateway/src/devmand/test/cli/utils/Log.h
+++ b/devmand/gateway/src/devmand/test/cli/utils/Log.h
@@ -10,7 +10,6 @@
 #define LOG_WITH_GLOG
 
 #include <magma_logging.h>
-#include <atomic>
 
 namespace devmand {
 namespace test {
@@ -19,9 +18,12 @@ namespace log {
 
 using namespace std;
 
-extern atomic_bool loggingInitialized;
-
 extern void initLog(uint32_t verbosity = MDEBUG);
+
+class TestLogInitializer {
+ public:
+  TestLogInitializer();
+};
 
 } // namespace log
 } // namespace utils


### PR DESCRIPTION
Wire cli Engine to IoConfigurationBuilder.
Prepare dependencies for configuring threadpools via Engine.
Add TestLogInitializer class that initializes logging on debug level,
see ReconnectingSshTest for usage.
Reconfigure executors so that they are not created per ssh session,
but reused. Create 'kaCliExecutor' CPU executor for keepalive,
'sshCliExecutor' for ssh layer, 'commonCli' CPU executor for all
other cli layers.
Replace plaintextCliDevice executor with Engine::getExecutor.