### PR TITLE
Define CliException and fix exception related TODOs

### DIFF
--- a/devmand/gateway/src/devmand/channels/cli/Cli.h
+++ b/devmand/gateway/src/devmand/channels/cli/Cli.h
@@ -38,6 +38,26 @@ class Cli {
       const WriteCommand cmd) = 0;
 };
 
+class CliException : public std::runtime_error {
+ public:
+  CliException(string msg) : std::runtime_error(msg) {}
+};
+
+class DisconnectedException : public CliException {
+ public:
+  DisconnectedException(string msg = "Not connected") : CliException(msg) {}
+};
+
+class CommandExecutionException : public CliException {
+ public:
+  CommandExecutionException(string msg = "Command execution failed") : CliException(msg) {}
+};
+
+class CommandTimeoutException : public CommandExecutionException {
+ public:
+  CommandTimeoutException(string msg = "Command execution timed out") : CommandExecutionException(msg) {}
+};
+
 } // namespace cli
 } // namespace channels
 } // namespace devmand

--- a/devmand/gateway/src/devmand/channels/cli/SshSession.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/SshSession.cpp
@@ -77,7 +77,7 @@ void SshSession::openShell(
 
   sessionState.channel.store(ssh_channel_new(sessionState.session));
   if (sessionState.channel == nullptr) {
-    terminate();
+    terminate<CliException>();
   }
 
   rc = ssh_channel_open_session(sessionState.channel);
@@ -97,10 +97,11 @@ bool SshSession::checkSuccess(int return_code, int OK_RETURN_CODE) {
   if (return_code == OK_RETURN_CODE) {
     return true;
   }
-  terminate(); // TODO is this an appropriate reaction to every problem??
+  terminate<CliException>(); // TODO is this an appropriate reaction to every problem??
   return false;
 }
 
+template <typename E>
 void SshSession::terminate() {
   const char* error_message = sessionState.session != nullptr
       ? ssh_get_error(sessionState.session)
@@ -110,7 +111,7 @@ void SshSession::terminate() {
                << " port: " << sessionState.port
                << " with error: " << error_message;
   string error = "Error with SSH: ";
-  throw std::runtime_error(error + error_message);
+  throw E(error + error_message);
 }
 
 string SshSession::read(int timeoutMillis) {
@@ -133,7 +134,7 @@ string SshSession::read(int timeoutMillis) {
       MLOG(MERROR) << "[" << id << "] "
                    << "Error reading data from SSH connection, read bytes: "
                    << bytes_read;
-      terminate();
+      terminate<CommandExecutionException>();
     } else if (bytes_read == 0) {
       return result;
     } else {
@@ -159,7 +160,7 @@ void SshSession::write(const string& command) {
   if (bytes == SSH_ERROR) {
     MLOG(MERROR) << "[" << id << "] "
                  << "Error while executing command " << command;
-    terminate();
+    terminate<CommandExecutionException>();
   }
 }
 

--- a/devmand/gateway/src/devmand/channels/cli/SshSession.h
+++ b/devmand/gateway/src/devmand/channels/cli/SshSession.h
@@ -33,6 +33,7 @@ class SshSession {
   int verbosity;
 
   bool checkSuccess(int return_code, int OK_RETURN_CODE);
+  template <typename E>
   void terminate();
 
  public:

--- a/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
@@ -103,7 +103,7 @@ Future<string> TimeoutTrackingCli::executeSomething(
             // executor
             MLOG(MDEBUG) << "[" << params->id << "] (" << cmd << ") "
                          << "timing out";
-            throw FutureTimeout();
+            throw CommandTimeoutException();
           },
           timeoutTrackingParameters->timekeeper.get())
       .thenValue(

--- a/devmand/gateway/src/devmand/devices/cli/PlaintextCliDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/cli/PlaintextCliDevice.cpp
@@ -74,26 +74,28 @@ std::shared_ptr<State> PlaintextCliDevice::getState() {
   cmdCache->wlock()->clear();
   auto state = State::make(*reinterpret_cast<MetricSink*>(&app), getId());
 
-  state->addRequest(channel->executeRead(stateCommand)
-                        .via(executor.get())
-                        .thenValue([state, cmd = stateCommand](std::string v) {
-                          state->setStatus(true);
-                          state->update([&v, &cmd](auto& lockedState) {
-                            lockedState[cmd.raw()] = v;
-                          });
-                        })
-                        .thenError(
-                            folly::tag_t<std::exception>{},
-                            [state, id = this->id](std::exception const& e) {
-                              MLOG(MWARNING)
-                                  << "[" << id << "] "
-                                  << "Retrieving state failed: " << e.what();
-                              // FIXME catching exception type instead strcmp ?
-                              if (strcmp(e.what(), "Not connected") == 0) {
-                                state->setStatus(false);
-                              }
-                              state->addError(e.what());
-                            }));
+  state->addRequest(
+      channel->executeRead(stateCommand)
+          .via(executor.get())
+          .thenValue([state, cmd = stateCommand](std::string v) {
+            state->setStatus(true);
+            state->update(
+                [&v, &cmd](auto& lockedState) { lockedState[cmd.raw()] = v; });
+          })
+          .thenError(
+              folly::tag_t<DisconnectedException>{},
+              [state,
+               id = this->id](DisconnectedException const& e) -> Future<Unit> {
+                state->setStatus(false);
+                throw e;
+              })
+          .thenError(
+              folly::tag_t<std::exception>{},
+              [state, id = this->id](std::exception const& e) {
+                MLOG(MWARNING) << "[" << id << "] "
+                               << "Retrieving state failed: " << e.what();
+                state->addError(e.what());
+              }));
 
   return state;
 }

--- a/devmand/gateway/src/devmand/test/cli/ReconnectingSshTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/ReconnectingSshTest.cpp
@@ -108,16 +108,8 @@ TEST_F(ReconnectingSshTest, commandTimeout) {
   string sleepCommand = "sleep ";
   sleepCommand.append(to_string(cmdTimeout + 1));
   EXPECT_THROW(
-      {
-        try {
-          cli->executeRead(ReadCommand::create(sleepCommand, true))
-              .get(); // timeout exception
-        } catch (const exception& e) {
-          EXPECT_STREQ("Timed out", e.what());
-          throw;
-        }
-      },
-      exception);
+      { cli->executeRead(ReadCommand::create(sleepCommand, true)).get(); },
+      CommandTimeoutException);
 
   ssh->close();
   ssh = startSshServer();

--- a/devmand/gateway/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
@@ -79,7 +79,8 @@ TEST_F(TimeoutCliTest, cleanDestructOnTimeout) {
   // Destruct cli
   testedCli.reset();
 
-  EXPECT_THROW(move(future).via(testExec.get()).get(10s), FutureTimeout);
+  EXPECT_THROW(
+      move(future).via(testExec.get()).get(10s), CommandTimeoutException);
 }
 
 TEST_F(TimeoutCliTest, cleanDestructOnError) {


### PR DESCRIPTION
Reconnect is now triggerred only when a timeout occurs, write fails or
read fails.

Exception types are preserved across the CLI stack.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>